### PR TITLE
Add release automation and update CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          # Get the previous tag
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "notes=Initial release" >> $GITHUB_OUTPUT
+          else
+            # Generate changelog from commits since last tag
+            NOTES=$(git log --pretty=format:"- %s (%h)" $PREV_TAG..HEAD^ | head -50)
+            # Use a delimiter for multiline output
+            echo "notes<<EOF" >> $GITHUB_OUTPUT
+            echo "$NOTES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Determine if prerelease
+        id: prerelease
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if echo "$TAG_NAME" | grep -q '-'; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: |
+            ## Changes
+
+            ${{ steps.changelog.outputs.notes }}
+
+            ## Installation
+
+            ```bash
+            go get github.com/ecadlabs/gotez/v2@${{ github.ref_name }}
+            ```
+          draft: false
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,19 @@
-on: [push, pull_request]
 name: Test
+
+on:
+  push:
+    branches: [v2]
+  pull_request:
+    branches: [v2]
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
         with:
-          go-version: ">=1.19.0"
-      - uses: actions/checkout@v3
+          go-version-file: go.mod
+
       - run: go test ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+<!--
+## [v2.x.x] - YYYY-MM-DD
+
+### Added
+- New features
+
+### Changed
+- Changes in existing functionality
+
+### Fixed
+- Bug fixes
+
+### Removed
+- Removed features
+-->


### PR DESCRIPTION
## Summary

- Add automated release workflow triggered on version tag push (`v*`)
- Update test workflow with newer GitHub Action versions
- Add CHANGELOG.md template following Keep a Changelog format

## Changes

### `.github/workflows/release.yml` (new)
- Triggers on `v*` tags
- Runs tests before creating release
- Auto-generates changelog from commits since last tag
- Creates GitHub release with installation instructions
- Marks pre-release versions (tags containing `-`) appropriately

### `.github/workflows/test.yml`
- Updated `actions/checkout` to v4
- Updated `actions/setup-go` to v5
- Now uses `go-version-file: go.mod` instead of hardcoded version
- Scoped to only run on `v2` branch pushes and PRs

### `CHANGELOG.md`
- Template following [Keep a Changelog](https://keepachangelog.com/) format

## Usage

To create a release:
```bash
git tag v2.x.x
git push origin v2.x.x
```