### PR TITLE
Decode round from fitness and use it in getround for proposals

### DIFF
--- a/protocol/core/shell.go
+++ b/protocol/core/shell.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"encoding/binary"
+	"errors"
 	tz "github.com/ecadlabs/gotez/v2"
 	"github.com/ecadlabs/gotez/v2/encoding"
 )
@@ -14,6 +16,26 @@ type ShellHeader struct {
 	OperationsHash *tz.OperationsHash `json:"operations_hash"`
 	Fitness        tz.Bytes           `tz:"dyn" json:"fitness"`
 	Context        *tz.ContextHash    `json:"context"`
+}
+
+// GetRoundFromTenderbakeBlock extracts the round from a Tenderbake block fitness
+func GetRoundFromTenderbakeBlock(data tz.Bytes) (uint32, error) {
+	/* FITNESS=
+	   (<fitness_length(4)> not in gotez)
+	   <version_len(4)><version(1)>
+	   <level_len(4)><level(4)>
+	   <locked_round_len(4)><locked_round(0 OR 4)>
+	   <predecessor_round_len(4)><predecessor_round(4)>
+	   <round_len(4)><round(4)> */
+
+	if len(data) < 4 {
+		return 0, errors.New("data too short to extract round")
+	}
+	// The fitness data has been stripped from its prefixed length
+	// The round value is always the 4 last bytes
+	round := binary.BigEndian.Uint32(data[len(data)-4:])
+
+	return round, nil
 }
 
 type BlockMetadataHeader struct {

--- a/protocol/proto_022_PsRiotum/sign_request.go
+++ b/protocol/proto_022_PsRiotum/sign_request.go
@@ -56,7 +56,13 @@ type BlockSignRequest struct {
 
 func (r *BlockSignRequest) GetChainID() *tz.ChainID { return r.Chain }
 func (r *BlockSignRequest) GetLevel() int32         { return r.BlockHeader.Level }
-func (r *BlockSignRequest) GetRound() int32         { return r.BlockHeader.PayloadRound }
+func (r *BlockSignRequest) GetRound() int32 {
+	round, err := core.GetRoundFromTenderbakeBlock(r.BlockHeader.Fitness)
+	if err != nil {
+		fmt.Println("Error: ", err)
+	}
+	return int32(round)
+}
 func (*BlockSignRequest) SignRequestKind() string   { return "block" }
 
 type ConsensusSignRequest[T core.OperationContents] struct {


### PR DESCRIPTION
Hi 👋

I work at Nomadic Labs on Octez.

Some bakers recently missed slots, and after investigation we isolated the issue in Signatory: it was unable to sign reproposals (same payload at a higher round). This PR addresses that issue.

To test this patch I have setup a sandbox network with a signatory using this patch. I have tried to repropose with the same payload using
```
./octez-client --endpoint http://127.0.0.1:18731/ -d /tmp/tezos-client-signatory repropose for baker1 --minimal-timestamp --force-reproposal
```
(`/tmp/tezos-client-signatory` is a client that uses remote keys from a signatory instance)

Please let me know if you’d like any additional context or the full testing scenario.