### PR TITLE
Fix proto_024 ManagerMetadata missing ManagerOperationMetadata methods

### DIFF
--- a/protocol/proto_024_PtTALLiN/operations.go
+++ b/protocol/proto_024_PtTALLiN/operations.go
@@ -355,6 +355,19 @@ type ManagerMetadata[T core.ManagerOperationResult] struct {
 	InternalOperationResults []InternalOperationResult `tz:"dyn" json:"internal_operation_results"`
 }
 
+var _ core.ManagerOperationMetadata = (*ManagerMetadata[ConsumedGasResult])(nil)
+
+func (m *ManagerMetadata[T]) GetResult() core.ManagerOperationResult {
+	return m.OperationResult
+}
+func (m *ManagerMetadata[T]) GetInternalOperationResults() []core.InternalOperationResult {
+	out := make([]core.InternalOperationResult, len(m.InternalOperationResults))
+	for i, r := range m.InternalOperationResults {
+		out[i] = r
+	}
+	return out
+}
+
 type InternalOperationResult interface {
 	core.InternalOperationResult
 }


### PR DESCRIPTION
## Summary

- `proto_024_PtTALLiN.ManagerMetadata` was defined as a new struct (can't alias proto_023's because it uses proto_024's own `InternalOperationResult` with `AddressRegistryDiff`) but was missing `GetResult()` and `GetInternalOperationResults()`
- Without these, `*ManagerMetadata[T]` doesn't satisfy `core.ManagerOperationMetadata`, so `collectMilligasAndStorage` silently returns `(0, 0)` and `teztool.Fill` sets `gas_limit=0` / `storage_limit=0` on all operations
- Added compile-time interface satisfaction check (`var _`) to prevent this class of regression

## Verification

Decoded an actual `run_operation` binary response from PtTALLiNt shadownet (`https://shadownet.tezos.ecadinfra.com`). Confirmed variant tag is `0x00` (with metadata, not variant 1 as initially suspected), and `consumed_milligas = 2168755` is now correctly extracted.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Compile-time check catches the bug (verified by temporarily removing `GetResult()`)
- [x] End-to-end decode of live shadownet `run_operation` response extracts `consumed_milligas` correctly