### PR TITLE
Tighten CI workflows: vet, race detector, concurrency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,33 +14,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
+      - name: Vet
+        run: go vet ./...
+
       - name: Run tests
-        run: go test ./...
-
-      - name: Generate changelog
-        id: changelog
-        run: |
-          # Get the previous tag
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-
-          if [ -z "$PREV_TAG" ]; then
-            echo "notes=Initial release" >> $GITHUB_OUTPUT
-          else
-            # Generate changelog from commits since last tag
-            NOTES=$(git log --pretty=format:"- %s (%h)" $PREV_TAG..HEAD^ | head -50)
-            # Use a delimiter for multiline output
-            echo "notes<<EOF" >> $GITHUB_OUTPUT
-            echo "$NOTES" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          fi
+        run: go test -race -count=1 ./...
 
       - name: Determine if prerelease
         id: prerelease
@@ -56,16 +40,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          body: |
-            ## Changes
-
-            ${{ steps.changelog.outputs.notes }}
-
-            ## Installation
-
-            ```bash
-            go get github.com/ecadlabs/gotez/v2@${{ github.ref_name }}
-            ```
+          generate_release_notes: true
           draft: false
           prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [v2]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,4 +20,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - run: go test ./...
+      - run: go vet ./...
+
+      - run: go test -race -count=1 ./...


### PR DESCRIPTION
## Summary
- Add `go vet ./...` before tests in both test and release workflows
- Enable race detector and disable test caching (`-race -count=1`) for both workflows
- Add concurrency group to test workflow to cancel in-flight runs on the same PR
- Replace custom git-log changelog (fragile with non-linear history) with GitHub's built-in `generate_release_notes`

## Test plan
- [ ] Confirm test workflow triggers on this PR with vet + race-enabled tests
- [ ] Review release workflow YAML for correctness (tag pushes can't be tested without tagging)