### PR TITLE
fix(mempool): use dyn-encoded Branch for PendingOperationsListWithError in TallinN

### DIFF
--- a/clientv2/mempool/mempool.go
+++ b/clientv2/mempool/mempool.go
@@ -24,8 +24,10 @@ type PendingOperationsList struct {
 }
 
 type PendingOperationsListWithError struct {
-	PendingOperationsList
-	Error []byte `tz:"dyn" json:"error"`
+	Hash     *tz.OperationHash                                          `json:"hash"`
+	Branch   *tz.BlockHash                                              `tz:"dyn" json:"branch"`
+	Contents []*core.OperationWithoutMetadata[latest.OperationContents] `tz:"dyn" json:"contents"`
+	Error    []byte                                                     `tz:"dyn" json:"error"`
 }
 
 type UnprocessedPendingOperationsList struct {


### PR DESCRIPTION
## Problem

TallinN (proto_024 `PtTALLiNtPec7mE7yY4m3k26J8Qukef3E3ehzhfXgFZKGtDdAXu`) changed the wire encoding for `refused`, `outdated`, `branch_refused`, and `branch_delayed` operations: the `Branch` field is now **dyn-prefixed** (4-byte big-endian uint32 length `0x00000020` = 32, then 32 bytes) instead of the raw 32-byte encoding used in earlier protocols.

`validated` ops still use raw 32-byte Branch — only the error bucket types changed.

## Impact

`PendingOperationsListWithError` embeds `PendingOperationsList` which uses raw Branch. When decoding TallinN refused/outdated ops:

1. The 4-byte dyn prefix `0x00000020` is read as the last 4 bytes of the Branch hash
2. The next 4 bytes of the actual Branch bytes get interpreted as the `Contents` dyn length
3. Those bytes produce enormous values (e.g. `3,681,343,224`) → `"buffer is too short, at least 3681343224 byte(s) were expected"`

The sidecar doesn't crash — ops that fail to parse are skipped — but mempool counts are under-reported for all non-validated operations.

## Fix

Inline the fields from `PendingOperationsList` into `PendingOperationsListWithError` and add `tz:"dyn"` to the `Branch` field.

`PendingOperationsList` itself is **unchanged** — validated ops still use raw Branch encoding.

`UnprocessedPendingOperationsList` already has `tz:"dyn"` on Branch and is unaffected.

## Verification

- `go test ./...` passes, including `clientv2/mempool` and `proto_024_PtTALLiN`
- Root cause confirmed by binary inspection of live TallinN shadownet mempool responses: all refused/outdated ops have `0x00000020` at offset 0 of the Branch field; validated ops use raw 32-byte Branch