### PR TITLE
core.Validator interface

### DIFF
--- a/protocol/core/types.go
+++ b/protocol/core/types.go
@@ -314,3 +314,8 @@ type PackData struct {
 }
 
 func (PackData) SignRequestKind() string { return "pack" }
+
+// Validator interface may be implemented by some operations to allow pre-flight validation before signing/injection
+type Validator interface {
+	Validate() error
+}

--- a/protocol/proto_023_PtSeouLo/operations.go
+++ b/protocol/proto_023_PtSeouLo/operations.go
@@ -3,6 +3,7 @@ package proto_023_PtSeouLo
 //go:generate go run ../../cmd/genmarshaller.go
 
 import (
+	"errors"
 	"strconv"
 
 	tz "github.com/ecadlabs/gotez/v2"
@@ -124,6 +125,15 @@ func (*UpdateConsensusKey) OperationKind() string { return "update_consensus_key
 type UpdateCompanionKey UpdateConsensusKey
 
 func (*UpdateCompanionKey) OperationKind() string { return "update_companion_key" }
+
+func (u *UpdateCompanionKey) Validate() error {
+	if _, ok := u.PublicKey.(*tz.BLSPublicKey); !ok {
+		return errors.New("companion key is not a BLS key")
+	}
+	return nil
+}
+
+var _ core.Validator = (*UpdateCompanionKey)(nil)
 
 //json:kind=OperationKind()
 type Attestation proto_022_PsRiotum.Attestation


### PR DESCRIPTION
core.Validator interface may be implemented by some operations to allow pre-flight validation before signing/injection. Currently implemented by `UpdateCompanionKey` to check if the key is BLS public key.
In the future U protocol it must be also  implemented by `UpdateConsensusKey` and `Delegation` operations to check if the key/address is not a MLDSA44 key/address
